### PR TITLE
Make unit tests stricter

### DIFF
--- a/test/unit/DependencyInjection/SexyFieldFormExtensionTest.php
+++ b/test/unit/DependencyInjection/SexyFieldFormExtensionTest.php
@@ -13,6 +13,8 @@ use Mockery as M;
  */
 class SexyFieldFormExtensionTest extends TestCase
 {
+    use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
     /**
      * @test
      * @covers ::load

--- a/test/unit/SectionField/Form/FormTest.php
+++ b/test/unit/SectionField/Form/FormTest.php
@@ -29,6 +29,8 @@ use Tardigrades\SectionField\ValueObject\Slug;
  */
 class FormTest extends TestCase
 {
+    use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
     /** @var SectionManagerInterface|M\Mock */
     private $sectionManager;
 
@@ -154,7 +156,7 @@ class FormTest extends TestCase
             ->andReturn(new ArrayCollection([$field]));
 
         $this->sectionManager->shouldReceive('readByHandle')
-            ->once()
+            ->twice()
             ->andReturn($mockedSectionManagerInterface);
 
         $sexyEntity = M::mock(SectionEntityInterface::class)->makePartial();

--- a/test/unit/Twig/SectionFormTwigExtensionTest.php
+++ b/test/unit/Twig/SectionFormTwigExtensionTest.php
@@ -20,6 +20,8 @@ use Tardigrades\SectionField\Form\FormInterface;
  */
 class SectionFormTwigExtensionTest extends TestCase
 {
+    use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
     /** @var SectionManagerInterface|Mockery\Mock */
     private $sectionManager;
 
@@ -122,8 +124,6 @@ class SectionFormTwigExtensionTest extends TestCase
             'redirect' => '/myPlace/'
         ];
 
-        $dummyData = 'trololo';
-
         $mockedForm = Mockery::mock(Form::class)->makePartial();
 
         $this->form->shouldReceive('buildFormForSection')
@@ -132,12 +132,11 @@ class SectionFormTwigExtensionTest extends TestCase
 
         $this->form->shouldReceive('hasRelationship')->never();
 
-        $this->createSection->shouldReceive('save')->once()
-            ->with($dummyData, ['nope']);
+        $this->createSection->shouldReceive('save')->never();
 
         $mockedForm->shouldReceive('handleRequest')->once();
-        $mockedForm->shouldReceive('isSubmitted')->once()->andReturn(false);
-        $mockedForm->shouldReceive('isValid')->once()->andReturn(true);
+        $mockedForm->shouldReceive('isSubmitted')->andReturn(false);
+        $mockedForm->shouldReceive('isValid')->andReturn(true);
         $mockedForm->shouldReceive('getData')->never();
         $mockedFormView = Mockery::mock(FormView::class)->makePartial();
         $mockedForm->shouldReceive('createView')->once()->andReturn($mockedFormView);


### PR DESCRIPTION
With the `MockeryPHPUnitIntegration` trait the number of times a method is called is verified.